### PR TITLE
tooltips for map controls, and some fan-mail

### DIFF
--- a/site/templates/make-step2-geography.html.tpl
+++ b/site/templates/make-step2-geography.html.tpl
@@ -245,13 +245,13 @@
             </form>
             <div id="zoom-container">
                 <span id="zoom-in" style="display: none;">
-                    <img src="{$base_dir}/img/button-zoom-in-off.png" id="zoom-in-button" width="46" height="46">
+                    <img src="{$base_dir}/img/button-zoom-in-off.png" id="zoom-in-button" width="46" height="46" title="Zoom In">
                 </span>
                 <span id="zoom-out" style="display: none;">
-                    <img src="{$base_dir}/img/button-zoom-out-off.png" id="zoom-out-button" width="46" height="46">
+                    <img src="{$base_dir}/img/button-zoom-out-off.png" id="zoom-out-button" width="46" height="46" title="Zoom Out">
                 </span>
                 <span id="zoom-return">
-                    <img src="{$base_dir}/img/button-return-off.png" id="zoom-return-button" width="46" height="46">
+                    <img src="{$base_dir}/img/button-return-off.png" id="zoom-return-button" width="46" height="46" title="Return the Atlas to the Center of the Map">
                 </span>
             </div>
             <div id="map">


### PR DESCRIPTION
Mainly sending this pull request as fan-mail for the return button and its hover state: ![Return Off](http://fieldpapers.org/img/button-return-off.png) and ![Return On](http://fieldpapers.org/img/button-return-on.png). Love it!

However, even though I love it I wasn't sure what it did and I hoped to get clarification when I hovered. I've added some tooltips to the map controls in the form of `title` attributes to fix this. Feel free to close this pull request and implement these yourselves, but I didn't want to whine without offering a solution :)

Congrats on the launch Stamen folks, it's a lovely thing!
