### PR TITLE
fixed navbar wrap to newline issue introduced with extend nav li 

### DIFF
--- a/site/www/css/fieldpapers.css
+++ b/site/www/css/fieldpapers.css
@@ -113,6 +113,7 @@ a:hover, a:active, a:focus {
 .navbar ul {
 	list-style:none;
 	float: left;
+	padding-left: 0px;
 }
 .navbar li {
 	margin-right: 30px;


### PR DESCRIPTION
Hey thought this was fixed a while ago, but I've been seeing the top nav wrap around to a second line.  I removed left-padding on nav ul to fix this issue.
