### PR TITLE
Tell user what to do if atlases are stuck

### DIFF
--- a/site/templates/atlas.html.tpl
+++ b/site/templates/atlas.html.tpl
@@ -613,6 +613,7 @@
                     This may take a while, generally a few minutes. <br><br>
                     You don't need to keep this window open; you can <a href="{$base_dir}/atlas.php?id={$print.id|escape}">bookmark 
                     this page</a> and come back later.
+                    <br><br>If it takes more than an hour, check <a href="http://twitter.com/fieldpapers">@fieldpapers on twitter</a> for system status updates, and email us at help@fieldpapers.org if your atlas is stuck.
                 </p>
                 {if $print.private}
                 <p>


### PR DESCRIPTION
I didn't get a chance to test this... hopefully I'm not messing up the template.

We definitely need some kind of message on the atlas generation page so that people know how to contact us if the atlases get stuck.
