### PR TITLE
added additional argument to _cairo.so after getting segmentation faults

### DIFF
--- a/decoder/svgutils.py
+++ b/decoder/svgutils.py
@@ -102,6 +102,12 @@ def create_cairo_font_face_for_file(filename, faceindex=0, loadoptions=0):
     _freetype_so = ctypes.CDLL('libfreetype.so.6')
     _cairo_so = ctypes.CDLL('libcairo.so.2')
 
+    _cairo_so.cairo_ft_font_face_create_for_ft_face.restype = ctypes.c_void_p
+    _cairo_so.cairo_ft_font_face_create_for_ft_face.argtypes = [ ctypes.c_void_p, ctypes.c_int ]
+    _cairo_so.cairo_set_font_face.argtypes = [ ctypes.c_void_p, ctypes.c_void_p ]
+    _cairo_so.cairo_font_face_status.argtypes = [ ctypes.c_void_p ]
+    _cairo_so.cairo_status.argtypes = [ ctypes.c_void_p ]
+
     # initialize freetype
     _ft_lib = ctypes.c_void_p()
     if FT_Err_Ok != _freetype_so.FT_Init_FreeType(ctypes.byref(_ft_lib)):


### PR DESCRIPTION
When testing fieldpapers on Ubuntu 12.04 64bit, I consistently got a Segmentation Fault during use of cairo shared object from decoder/svgutils.  I found the fix right in the doc string for the function which included a link to the code example that was used for interfacing with cairo through ctypes.

I added the missing argument mapping in and everything is working fine on precise64.

http://cairographics.org/freetypepython/

Any idea why these argument may have been removed earlier?  In any case, not more seg fault.
