### PR TITLE
added simple backup and restore scripts

### DIFF
--- a/site/simple_backup.sh
+++ b/site/simple_backup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+echo 'Creating fieldpapers backup'
+today=`date +"%Y-%m-%d"`
+current_dir=`pwd`
+backup_dir="fieldpapers-backup-${today}"
+output_archive="${current_dir}/${backup_dir}.tar.gz"
+
+mkdir -p $backup_dir
+cd $backup_dir
+mkdir -p files
+rsync -r /usr/local/fieldpapers/site/www/files/ ./files/
+mysqldump -u fieldpapers -pw4lks fieldpapers > fieldpapers_db.sql
+cd ..
+tar -zcvf $output_archive $backup_dir
+echo $output_archive
+rm -rf $backup_dir

--- a/site/simple_restore.sh
+++ b/site/simple_restore.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo 'Restoring fieldpapers database and files directory'
+site_archive=$1
+backup_name=$(basename "$1" .tar.gz)
+tar -xzvf $site_archive
+cd $backup_name
+
+echo 'restoring database...'
+mysql -u fieldpapers -pw4lks fieldpapers < fieldpapers_db.sql
+
+echo 'restore files...'
+rsync -r ./files/ /usr/local/fieldpapers/site/www/files/


### PR DESCRIPTION
This is a quick-and-dirty backup of fieldpapers database and files content. 

I've included two script `simple_backup.sh` and `simple_restore.sh`

Example using `simple_backup.sh`:
```bash
#!/bin/bash                                                                                              
conn="vagrant@192.168.33.10"                                                                                                                                         
backup=`ssh $conn "bash /usr/local/fieldpapers/site/simple_backup.sh | grep tar.gz"`                                                                                         
scp "$conn:${backup}" ./   
```
Example using `simple_restore.sh`:

```bash
#!/bin/bash                                                                                              
conn="vagrant@192.168.33.10" 
restore_file=fieldpapers-backup-2015-02-06.tar.gz
scp $restore_file "${conn}:/tmp/"
ssh $conn " bash /usr/local/fieldpapers/site/simple_restore.sh /tmp/${restore_file}" 
```
